### PR TITLE
Automated packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 dist
+node_modules

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "pact-mock-service": "./bin/pact-mock-service"
   },
   "scripts": {
+    "preinstall": "node scripts/preinstall.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -27,5 +28,8 @@
   "bugs": {
     "url": "https://github.com/bethesque/pact-mock_service/issues"
   },
-  "homepage": "https://github.com/bethesque/pact-mock-service-npm"
+  "homepage": "https://github.com/bethesque/pact-mock-service-npm",
+  "dependencies": {
+    "npm": "^2.9.1"
+  }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,20 +15,19 @@ export EXTENSION='zip'
 scripts/package_for_npm.sh
 
 export STANDALONE_PACKAGE_NAME="pact-mock-service-$PACKAGE_VERSION-osx"
-export NPM_PACKAGE_NAME='pact-mock-service-osx'
+export NPM_PACKAGE_NAME='pact-mock-service-darwin'
 export SUFFIX='osx'
 export EXTENSION='tar.gz'
 scripts/package_for_npm.sh
 
 export STANDALONE_PACKAGE_NAME="pact-mock-service-$PACKAGE_VERSION-linux-x86"
-export NPM_PACKAGE_NAME='pact-mock-service-linux-x86'
+export NPM_PACKAGE_NAME='pact-mock-service-linux-ia32'
 export SUFFIX='linux-x86'
 export EXTENSION='tar.gz'
 scripts/package_for_npm.sh
 
 export STANDALONE_PACKAGE_NAME="pact-mock-service-$PACKAGE_VERSION-linux-x86_64"
-export NPM_PACKAGE_NAME='pact-mock-service-linux-x86_64'
+export NPM_PACKAGE_NAME='pact-mock-service-linux-x64'
 export SUFFIX='linux-x86_64'
 export EXTENSION='tar.gz'
 scripts/package_for_npm.sh
-

--- a/scripts/package_for_npm.sh
+++ b/scripts/package_for_npm.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-echo "Packaging $STANDALONE_PACKAGE_NAME.tar.gz for npm as $NPM_PACKAGE_NAME.tar.gz"
+echo "Packaging $STANDALONE_PACKAGE_NAME.$EXTENSION for npm as $NPM_PACKAGE_NAME.$EXTENSION"
 
 mkdir -p dist
 
@@ -20,8 +20,4 @@ cp ../$SUFFIX/package.json $STANDALONE_PACKAGE_NAME
 cp ../$SUFFIX/README.md $STANDALONE_PACKAGE_NAME
 cd $STANDALONE_PACKAGE_NAME
 
-if [ $EXTENSION = "zip" ]; then
-  zip -9r ../../dist/$NPM_PACKAGE_NAME.$EXTENSION .
-else
-  tar -czf ../../dist/$NPM_PACKAGE_NAME.$EXTENSION .
-fi
+tar -czf ../../dist/$NPM_PACKAGE_NAME.tar.gz .

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,0 +1,17 @@
+//Using preinstall hook, download and install the correct platform specific package for the mock server
+var npm = require("npm");
+var arch = "";
+npm.load(function(er, npm) {
+
+  if (process.platform === 'linux') {
+    arch = '-' + process.arch;
+  }
+  console.log("Installing Pact mock server for " + process.platform + arch);
+  npm.commands.install(['pact-mock-service-' + process.platform + arch], function(er, data) {
+    if(er) {
+      console.log(er);
+      process.exit(1);
+    }
+    console.log("Pact mock server for - " + process.platform + arch + " installed successfully.");
+  });
+})

--- a/win32/package.json
+++ b/win32/package.json
@@ -2,13 +2,13 @@
   "name": "pact-mock-service-win32",
   "version": "0.5.2-1",
   "description": "Pact mock service",
-  "main": "bin/pact-mock-service",
+  "main": "bin/pact-mock-service.bat",
   "directories": {
     "lib": "lib",
     "bin": "bin"
   },
   "bin": {
-    "pact-mock-service": "./bin/pact-mock-service"
+    "pact-mock-service": "./bin/pact-mock-service.bat"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Automated package selection based on platform npm install is being run from.

Will require renames to the current packages hosted on npms to match the naming scheme in package.json. These can be re-generated from scripts/build.sh if required.

For reference, these are:
pact-mock-service-linux-x64 -  Linux x86_64
pact-mock-service-linux-ia32 - Linux x86
pact-mock-service-darwin - osx
pact-mock-service-win32 - windows
