### PR TITLE
Update README for easier steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,12 @@ On install, this package selects and installs the correct [pact-mock-service-gem
 
 At the moment, this service simply downloads the appropriate platform-specific and installs it alongside `pact-mock-service` inside the node_modules directory. In the longer term however, this should transparently be installed within `pact-mock-service`.
 
-In the meantime however, below is a list of platform specific NPMs that may be downloaded on your behalf depending on your environment. 
-
-Substitute the following npm names in `[PLATFORM_SPECIFIC_NPM]` placeholder in the usage instructions below:
-
-* OS X - `pact-mock-service-darwin`
-* Windows - `pact-mock-service-win32`
-* Linux 32-bit - `pact-mock-service-linux-ia32`
-* Linux 64-bit - `pact-mock-service-linux-x64`
+In the meantime however, below is a list of platform specific NPMs that may be downloaded on your behalf depending on your environment.  **You will still need to install Ruby for this to work, suggest to install version 1.9.3**.
 
 ## Usage
 
     $ npm install pact-mock-service	
-    $ node_modules/[PLATFORM_SPECIFIC_NPM]/bin/pact-mock-service --port 1234
+    $ node_modules/.bin/pact-mock-service --port 1234
 
 # Known issues
 


### PR DESCRIPTION
don't need to point direction to the bin within the folder, you can simply use the .bin folder within node_modules.  Added mention of ruby dependency.
